### PR TITLE
Add branch protection hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     -   id: check-added-large-files
     -   id: check-merge-conflict
     -   id: detect-private-key
+    -   id: no-commit-to-branch
 
 -   repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.21.0


### PR DESCRIPTION
## Description

This PR introduces branch protection to prevent direct commits to the main branch.

## Changes:

- Added the no-commit-to-branch hook to .pre-commit-config.yaml to block local commits on main.
- Configured a corresponding GitHub Branch Protection Rule via the CLI to enforce pull requests and restrict force pushes on the remote.

These updates ensure a stable workflow by requiring all changes to pass through a feature branch and PR process.

