### PR TITLE
refactor: implement persistent tool cache

### DIFF
--- a/config.js
+++ b/config.js
@@ -12,8 +12,8 @@ module.exports = {
   // Storage and Caching
   baseDir: '/tmp/renovate', // Renovate's internal working directory
   cacheDir: '/tmp/renovate/cache', // Specific directory for persistent data
+  containerbaseDir: '/tmp/renovate/containerbase', // Specific directory for downloaded binaries/tools
   persistRepoData: true, // Speeds up nightly runs by keeping git clones
-
 
   // Execution Logic
   onboarding: true, // Creates an onboarding PR for new repos


### PR DESCRIPTION
This PR implements a persistent cache for dynamically installed tools
by configuring `containerbaseDir`. It ensures binaries are stored in
the mapped `/.data` volume.

Closes #2 
