### PR TITLE
fix: migrate to full image for artifact upload support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   renovate:
-    image: renovate/renovate:43.76.1
+    image: renovate/renovate:43.76.1-full
     container_name: renovate_bot
     # Uses shell variables, defaults to 1000:1000 if they aren't set
     user: "${RENOVATE_UID:-1000}:${RENOVATE_GID:-1000}"


### PR DESCRIPTION
This PR updates docker-compose.yml to pull the full Renovate image. This solves
an issue caused by missing or mismatched binaries on the slim image (default),
which led to artifact update failures on previous bot runs. 

Closes #6
