### PR TITLE
chore: add issue templates for features and bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,113 @@
+name: "Bug Report"
+description: "Report a reproducible issue or unexpected behavior"
+title: "[BUG] <short-description>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the fields below as completely as possible.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the problem.
+      placeholder: Short description of the bug
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected_area
+    attributes:
+      label: Affected area
+      description: What part of the project is affected?
+      options:
+        - Deployment (Docker/Shell)
+        - Configuration (config.js)
+        - Renovate Execution
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical
+        - Major
+        - Minor
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: Frequency
+      options:
+        - Always
+        - Intermittent
+        - Rare
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, versions, branch, toolchain, configuration, etc.
+      placeholder: |
+        OS:
+        Project version / commit:
+        Branch:
+        Toolchain / runtime:
+        Other relevant details:
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: List the steps needed to reproduce the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happens?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Logs, stack traces, screenshots, or configuration snippets.
+      render: text
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched for existing issues.
+          required: true
+        - label: I included environment details.
+          required: true
+        - label: I can reproduce this consistently (or described when it occurs).
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -57,16 +57,16 @@ body:
     validations:
       required: false
 
-  - type: dropdown
+  - type: checkboxes
     id: breaking_change
     attributes:
-      label: Does this introduce a breaking change?
-      description: A breaking change requires current users to modify their configuration or usage to retain existing behavior.
+      label: Breaking change
+      description: >
+        Check this box if this feature would require current users to change
+        their configuration or usage to retain existing behavior.
       options:
-        - No
-        - Yes
-    validations:
-      required: true
+        - label: This feature introduces a breaking change.
+          required: true
 
   - type: textarea
     id: migration_strategy

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,113 @@
+name: "Feature Request"
+description: "Propose a new idea or enhancement"
+title: "[FEATURE] <short-description>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to request new functionality or improvements.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence description of the feature or improvement.
+      placeholder: Short description of the desired feature
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this feature needed? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: Provide an example scenario showing how this feature would help.
+      placeholder: |
+        As a <role>, I want <capability>, so that <benefit>.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - High
+        - Medium
+        - Low
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Core
+        - Optional
+        - Integration
+    validations:
+      required: false
+
+  - type: dropdown
+    id: breaking_change
+    attributes:
+      label: Does this introduce a breaking change?
+      description: A breaking change requires current users to modify their configuration or usage to retain existing behavior.
+      options:
+        - No
+        - Yes
+    validations:
+      required: true
+
+  - type: textarea
+    id: migration_strategy
+    attributes:
+      label: Migration strategy
+      description: >
+        If this is a breaking change, describe how existing users can transition
+        (for example, flags, config options, or step-by-step changes). Optional
+        for non-breaking changes.
+      placeholder: |
+        - Existing behavior:
+        - New default behavior:
+        - Steps for users to retain the old behavior:
+        - Steps for users to adopt the new behavior:
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: Outline how this could be implemented or integrated. High-level design is sufficient.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: List other options you evaluated, if any, and why they are less suitable.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: The feature aligns with the project's goals.
+          required: false
+        - label: The feature does not duplicate existing functionality.
+          required: false
+        - label: Implementation complexity appears reasonable.
+          required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Added
+
+- GitHub issue templates for bug reports and feature requests.
+
 ## [v0.2.0] - 2026-03-16
 
 ### Added


### PR DESCRIPTION
## Summary

Add GitHub issue forms for feature requests and bug reports, and document them in the changelog.

## Changes

- Add feature request issue form (`.github/ISSUE_TEMPLATE/feature_request.yml`)
- Add bug report issue form (`.github/ISSUE_TEMPLATE/bug_report.yml`)
- Update `CHANGELOG.md` under `[Unreleased]` to mention the new templates

## Notes

- No user-facing behavior or API changes
- No version bump or release tag associated with this change

