### PR TITLE
feat(core): migrate from cron to systemd with advanced logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-03-30
+
+### Added
+
+- Documentation for migrating to Systemd `.service` and `.timer` units.
+- Unbuffered Perl-based log filtering in `run-renovate.sh` for clean
+`LVL [repo] msg` output.
+- Conditional timestamping logic to prevent duplication in system journals.
+
+### Changed
+
+- Optimized `docker-compose.yml` with persistent volume caching.
+- Refactored `run-renovate.sh` to support dual-stream logging (JSON to file,
+plain-text to console).
+
 ## [0.3.0] - 2026-03-19
 
 ### Changed
@@ -46,6 +61,7 @@ artifact upload failures.
 - `LICENSE` (MIT) and `README.md` with setup instructions.
 - `.dockerignore` safety mechanism to prevent credential leaks.
 
+[0.3.1]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.3.1
 [0.3.0]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.3.0
 [0.2.0]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.2.0
 [0.1.0]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -79,23 +79,75 @@ The main files and folders of this project are listed below.
 - Debug mode:
     `docker compose run --rm -e RENOVATE_LOG_LEVEL=debug renovate`
 
-## Automation (Cron)
+## Automation (Systemm & Cockpit)
 
-To automate the bot, add the script to your crontab by running `crontab -e`.
-The general format is:
-`MINUTE HOUR * * * /opt/renovate/run-renovate.sh`
+To bot is automated via **Systemd Timers** for better reliability and
+integrated logging via [Cockpit](https://cockpit-project.org).
 
-### Examples
+### Setup Service & Timer
 
-- **Nightly at 3:00 AM:**
-    `0 3 * * * /opt/renovate/run-renovate.sh`
-- **Weekly on sundays at 11:00 PM:**
-    `0 23 * * 0 /opt/renovate/run-renovate.sh`
-- **Twice daily (6 AM and 6 PM):**
-    `0 6,18 * * * /opt/renovate/run-renovate.sh`
+Create the following files in `/etc/systemd/system/`:
 
-> **Note:** Ensure you use the full absolute path to the script so cron can
-locate it regardless of the execution environment.
+- `renovate.service`:
+
+    ```ini
+    [Unit]
+        Description=Run Renovate Bot
+        Wants=network-online.target
+        After=network-online.target docker.service
+
+    [Service]
+        Type=oneshot
+        User=<your-username>
+        WorkingDirectory=/opt/renovate
+        ExecStart=/bin/bash /opt/renovate/run-renovate.sh
+        StandardOutput=journal
+        StandardError=journal
+
+    [Install]
+        WantedBy=multi-user.target
+    ```
+
+- `renovate.timer`:
+
+    ```ini
+    [Timer]
+        # See "Customizing the Schedule" below
+        OnCalendar=*-*-* 00,12:00:00
+        # Optional randomized delay up to 15 minutes
+        RandomizedDelaySec=15m
+        Persistent=true
+
+    [Install]
+        WantedBy=timers.target
+    ```
+
+### Customizing the Schedule
+
+To change how often the bot runs, edit the `OnCalendar` line in `renovate.timer`:
+
+- Twice daily (noon/midnight): `*-*-* 00,12:00:00`
+- Daily at 3 AM: `*-*-* 03:00:00`
+- Weekly on Mondays at 1 AM: `Mon *-*-* 01:00:00`
+- Hourly: hourly
+
+> Note: after changing the timer file, always run `sudo systemctl daemon-reload`
+to apply changes
+
+### Monitoring & Activation
+
+Enable the timer to start automatically on boot:
+
+```bash
+sudo systemctl enable --now renovate.timer
+```
+
+- Live logs: Real-time, filtered logs (info level) are streamed to `journalctl`
+    and can be visualized in the 'Services' tab in Cockpit.
+- Debug logs: full JSON logs are stored at `/opt/renovate/renovate.log`
+- Manual run: trigger an immedaite run with
+    `sudo systemctl start renovate.service` or by starting the service directly
+    from Cockpit.
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,27 @@ services:
       - ./config.js:/usr/src/app/config.js
       # Maps the local data folder to the container's working directory for caching
       - ./data:/tmp/renovate
+      # Mounts the current directory so Renovate can write the log file to it
+      - .:/usr/src/app/renovate-dir
     environment:
       - RENOVATE_TOKEN=${RENOVATE_TOKEN}
       - RENOVATE_AUTODISCOVER_FILTER=${RENOVATE_AUTODISCOVER_FILTER}
       - RENOVATE_GIT_AUTHOR=${RENOVATE_GIT_AUTHOR}
       - RENOVATE_TIMEZONE=${RENOVATE_TIMEZONE}
-      # Optional: Override log levels or tokens here if needed
-      - RENOVATE_LOG_LEVEL=info
+      # Logging
+      - LOG_LEVEL=info
+      - LOG_FORMAT=json
+      - LOG_FILE=/usr/src/app/renovate-dir/renovate.log
+      - LOG_FILE_LEVEL=debug
+      - LOG_FILE_FORMAT=json
+      # Trick reonvate into using 'pretty' log mode in a non-TTY environment
+      - FORCE_COLOR=0
+      # Clean logs: Disables ANSI colors and progress bar animations
+      # This ensures logs look good both in Cockpit and the local .log file
+      - NO_COLOR=true
+      - RENOVATE_REDACT_SECRETS=true
+      # Caching: Forces renovate to use your mounted /opt/renovate/data folder
+      # Prevents redownloading modules
+      - RENOVATE_CACHE_DIR=/tmp/renovate/cache
     # Ensures the container removes itself after the run finishes
     restart: "no"

--- a/run-renovate.sh
+++ b/run-renovate.sh
@@ -10,4 +10,33 @@ RENOVATE_GID=$(id -g)
 export RENOVATE_GID
 
 # Run Renovate and log the output
-/usr/bin/docker compose run --rm renovate > /opt/renovate/renovate.log 2>&1
+# stdbuf -oL ensures line-buffering for the docker command
+# perl -nle | autoflush(1) ensures the pipe itself doesn't buffer
+stdbuf -oL /usr/bin/docker compose run --rm renovate | perl -ne '
+    BEGIN { $| = 1 }
+    my ($time_raw) = /"time":"(.*?)"/;
+    my ($lvl_num) = /"level":(\d+)/;
+    my ($repo) = /"repository":"(.*?)"/;
+    my ($msg) = /"msg":"(.*?)"/;
+
+    next unless $msg;
+
+    # Map numeric level to text
+    my $lvl = ($lvl_num == 50) ? "ERROR" : ($lvl_num == 40) ? "WARN" : "INFO";
+
+    # Only show HH:MM:SS if running in a real terminal (not Systemd)
+    my $time = "";
+    if (-t STDOUT) {
+        $time_raw =~ s/[TZ]/ /g;
+        $time = substr($time_raw, 11, 8) . " ";
+    }
+
+    # Construct clean output line
+    my $current_line = "$time$lvl " . ($repo ? "[$repo] " : "") . $msg;
+
+    # De-duplicate identical consecutive lines for cleaner UI
+    if ($current_line ne $last_line) {
+        print "$current_line\n";
+        $last_line = $current_line;
+    }
+'


### PR DESCRIPTION
## Description

This PR replaces the legacy `crontab` automation with a modern **Systemd Service and Timer** architecture, enhancing observability.

## Key Changes

- Documentation: added configuration instructions for `.service` and `.timer` unit configurations for reliable scheduling
- Logging: implemented an unbuffered Perl-based log filter in `run-renovate.sh` to extract clean, text-based logs (`LVL [repo] msg`) for the Systemd Journal and Cockpit UI
- Observability: established dual-stream logging
    - Consolte: human-readable, conditional timestamps (terminal only)
    - File: Persistent, detailed JSON debug logs at `/opt/renovate/renovate.log`
- Performance: updated `docker-compose.yml` with persistent volume mapping for Renovate's cache to reduce I/O

## Testing

Below is the new, human-readable log format as seen in the terminal and Cockpit Services dashboard:

- Verified `run-renovate.sh` runs as a standalone executable and outputs timestamps correctly in a TTY
    
<img width="1423" height="239" alt="Screenshot 2026-03-30 at 4 22 15 PM" src="https://github.com/user-attachments/assets/f7cea07f-c298-4642-a795-ba53bc2cce7a" />


- Verified `renovate.service` outputs correctly in `journalctl` and Cockpit (no timestamps, no JSON noise)
    
<img width="1257" height="329" alt="Screenshot 2026-03-30 at 4 19 57 PM" src="https://github.com/user-attachments/assets/47d24f6f-f243-485f-925f-209b76a69172" />

