### PR TITLE
chore(logs): move logs to a central folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Renovate local data and cache
 data/
-renovate.log
+logs/
 
 # Created by https://www.toptal.com/developers/gitignore/api/linux,macos
 # Edit at https://www.toptal.com/developers/gitignore?templates=linux,macos

--- a/README.md
+++ b/README.md
@@ -144,7 +144,14 @@ sudo systemctl enable --now renovate.timer
 
 - Live logs: Real-time, filtered logs (info level) are streamed to `journalctl`
     and can be visualized in the 'Services' tab in Cockpit.
-- Debug logs: full JSON logs are stored at `/opt/renovate/renovate.log`
+- Debug logs: full JSON logs are stored at `/opt/renovate/logs/renovate.log`. To
+    integrate these with system logs, while maintaining the application
+    self-contained, use a symbolic link:
+
+    ```bash
+    sudo ln -sf /opt/renovate/logs /var/log/renovate
+    ```
+
 - Manual run: trigger an immedaite run with
     `sudo systemctl start renovate.service` or by starting the service directly
     from Cockpit.
@@ -158,7 +165,8 @@ Create a configuration file at `/etc/logrotate.d/renovate`:
 ```text
 /opt/renovate/renovate.log {
     daily
-    rotate 7
+    maxsize 50M
+    rotate 14
     compress
     delaycompress
     missingok

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,10 @@ services:
       # Logging
       - LOG_LEVEL=info
       - LOG_FORMAT=json
-      - LOG_FILE=/usr/src/app/renovate-dir/renovate.log
+      - LOG_FILE=/usr/src/app/renovate-dir/logs/renovate.log
       - LOG_FILE_LEVEL=debug
       - LOG_FILE_FORMAT=json
-      # Trick reonvate into using 'pretty' log mode in a non-TTY environment
+      # Trick renovate into using 'pretty' log mode in a non-TTY environment
       - FORCE_COLOR=0
       # Clean logs: Disables ANSI colors and progress bar animations
       # This ensures logs look good both in Cockpit and the local .log file


### PR DESCRIPTION
## Description

The previous configuration clutters the project's root directory
with logs as logrotate performs its rotation. Move logs to a
separate directory, and update README instructions to match the
new location.

Also add a maxsize trigger for log rotation, and update log
retention policy to 14 days.
