### PR TITLE
fix(infra): redirect Go cache to writable path

### DIFF
--- a/config.js
+++ b/config.js
@@ -46,4 +46,10 @@ module.exports = {
   extends: [
     'config:recommended' // Applies industry standard best practices
   ],
+  // Go override to ensure go tools have the right permissions
+  customEnvVariables: {
+    GOCACHE: '/tmp/renovate/cache/go-build',
+    GOPATH: '/tmp/renovate/cache/go',
+    HOME: '/tmp/renovate', // Keeps tools out of /home/ubuntu
+  }
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - RENOVATE_AUTODISCOVER_FILTER=${RENOVATE_AUTODISCOVER_FILTER}
       - RENOVATE_GIT_AUTHOR=${RENOVATE_GIT_AUTHOR}
       - RENOVATE_TIMEZONE=${RENOVATE_TIMEZONE}
+      - HOME=/tmp/renovate
       # Logging
       - LOG_LEVEL=info
       - LOG_FORMAT=json


### PR DESCRIPTION
## Description

This PR implements a fix for "Artifact update problems" encountered in repositories
with Go dependencies.

After Renovate updates a go dependency, it runs Go commands such as `go get` to
update any transitive dependencies required to ensure a tidy build. Go commands
attempt to write to `/home/ubuntu/.cache`, leading to `permission denied` as our bot
is configured.

## Changes implemented

- Updated `config.js` to explicitly set `GOCACHE`, `GOPATH`, and `HOME`
- Redirected these paths to `/tmp/renovate` and its subdirectories, which are
mapped to a persitent, writable host volume.

## Impact

These changes ensure that `go get` and other toolchain operations can successfully
complete artifact updates without requiring root access to the container's internal
filesystem.
