### PR TITLE
feat(integration): enable cross-repository post-upgrade script execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-27
+
+### Added
+
+- Support for post-upgrade script execution via `allowedCommands` and
+`allowShellExecutorForPostUpgradeCommands` global settings
+
 ## [0.3.1] - 2026-03-30
 
 ### Added
@@ -61,6 +68,7 @@ artifact upload failures.
 - `LICENSE` (MIT) and `README.md` with setup instructions.
 - `.dockerignore` safety mechanism to prevent credential leaks.
 
+[0.4.0]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.3.1
 [0.3.1]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.3.1
 [0.3.0]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.3.0
 [0.2.0]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.2.0

--- a/config.js
+++ b/config.js
@@ -46,6 +46,8 @@ module.exports = {
   extends: [
     'config:recommended' // Applies industry standard best practices
   ],
+  allowedCommands: ["^(?:\\./)?tools/[\\w-]+\\.sh.*$"],
+  allowShellExecutorForPostUpgradeCommands: true,
   // Go override to ensure go tools have the right permissions
   customEnvVariables: {
     GOCACHE: '/tmp/renovate/cache/go-build',


### PR DESCRIPTION
## Description

Enables the Renovate bot to execute custom scripts defined in a repository's `postUpgradeTasks`. This is essential for workflows that require secondary synchronization after a dependency update.

## What Changed

* Updated global `allowedCommands` to permit scripts in standardized `tools/` directories.
* Enabled `allowShellExecutorForPostUpgradeCommands` to support shell features like wildcards.

## Impact

Managed repositories can now automate ecosystem-specific tasks (e.g., syncing Grafana dashboards) securely via their local `tools/` directory.

## ⚠️ Mandatory Bot Configuration Note

Ensure the self-hosted environment has the updated `config.js` before processing repositories with these tasks.

## ⚠️ Security Warning

Enabling `postUpgradeTasks` in a self-hosted environment assumes a high trust relationship with all monitored repositories. Because the update process runs with the same user privileges as the Renovate process, any script in the whitelisted `tools/` directory could potentially exfiltrate sensitive data or execute arbitrary code.

### Mitigation Requirements

- **Vetting**: Thoroughly vet and monitor all repositories before integration.
- **Principle of Least Privilege**: Configure the environment running Renovate with only the minimum necessary permissions to reduce the impact of any malicious execution.
- **Isolation**: Bot managers must sandbox their environment (e.g., using isolated containers) and regularly review post-upgrade scripts to ensure they do not perform risky operations.

## Related

Closes #22 