### PR TITLE
feat(config): enable silent automerge for security vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-02
+
+### Added
+
+- Security: Enabled "silent patching" for `vulnerabilities` via `automerge` and
+`osvVulnerabilityAlerts`.
+- Config: Added `requiredStatusChecks: []` to security rules to allow immediate
+remediation (overridable per-repo).
+
+### Changed
+
+- Config: Switched security matching to `matchUpdateTypes: ["security"]` for
+better precision.
+- Privacy: Scrubbed security-related labels and dashboard tags to obfuscate
+vulnerability disclosures.
+- PRs: Standardized security branch naming and removed commit message suffixes.
+
 ## [0.4.0] - 2026-04-27
 
 ### Added
@@ -68,7 +85,8 @@ artifact upload failures.
 - `LICENSE` (MIT) and `README.md` with setup instructions.
 - `.dockerignore` safety mechanism to prevent credential leaks.
 
-[0.4.0]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.3.1
+[0.5.0]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.5.0
+[0.4.0]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.4.0
 [0.3.1]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.3.1
 [0.3.0]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.3.0
 [0.2.0]: https://github.com/Marlon-Gomes/renovate-pi-bot/releases/tag/v0.2.0

--- a/config.js
+++ b/config.js
@@ -15,6 +15,11 @@ module.exports = {
   containerbaseDir: '/tmp/renovate/containerbase', // Specific directory for downloaded binaries/tools
   persistRepoData: true, // Speeds up nightly runs by keeping git clones
 
+  // Global Settings
+  extends: [
+    'config:recommended' // Applies industry standard best practices
+  ],
+
   // Dashboard and Lifecycle
   dependencyDashboard: true,
   rebaseWhen: 'conflicted',
@@ -25,26 +30,31 @@ module.exports = {
   timezone: process.env.RENOVATE_TIMEZONE || 'UTC',
 
   // Security Scanning and Prioritization
+  osvVulnerabilityAlerts: true,
   vulnerabilityAlerts: {
     enabled: true,
+    branchTopic: "{{depNameSanitized}}-{{newMajor}}.x",
+    commitMessageSuffix: ""
   },
-  osvVulnerabilityAlerts: true,
 
   packageRules: [
     {
       // Match all security-related updates
-      matchCategories: ["security"],
+      matchUpdateTypes: ["security"],
       // Set limit to 0 to bypass the default 2 PR/hour limit from config
       prHourlyLimit: 0,
       // Ensures no labels are added to the PR
       addLabels: [],
       // Ensures no security labels are added to the Dashboard issue
-      dependencyDashboardLabels: []
+      dependencyDashboardLabels: [],
+      // Enable silent patching
+      automerge: true,
+      automergeType: "pr", // Creates PR then merges it
+      automergeStrategy: "squash",
+      // By-pass the need for a passing status check
+      // WARNING: Repos with status checks should enable them in their own renovate.json
+      requiredStatusChecks: [],
     }
-  ],
-  // Global Settings
-  extends: [
-    'config:recommended' // Applies industry standard best practices
   ],
   allowedCommands: ["^(?:\\./)?tools/[\\w-]+\\.sh.*$"],
   allowShellExecutorForPostUpgradeCommands: true,


### PR DESCRIPTION
## Description

This PR updates the bot's global configuration to implement a "Silent Patch" workflow
for security vulnerabilities.

## Reasoning

We determined that completely scrubbing vulnerability tables from PR bodies is not
natively supported by Renovate's security logic without disabling alerts entirely.
To balance security tracking with discretion, we are switching to an automerge
strategy.

## Key Changes

- **Automerge Enabled** (breaking): Security PRs will now be created and merged automatically
`(automergeType: "pr", strategy: "squash")`.
- **Disable Status Checks** (breaking): This update sets `requiredStatusChecks` to an
empty array for all security-related PRs. 
- **Label Scrubbing**: Removed PR `[SECURITY]` and branch name `vulnerability`
suffixes to avoid broadcasting vulnerability status on the dashboard.

## Impact

Renovate will now automerge security patches immediately without waiting for CI/CD or
status checks to pass.

## Migration

To upgrade from v.0.4.0, clients must ensure that:

- **Automerge** and **squash and merge** are enabled in repository settings
- Any repository that strictly requires status checks for security fixes must
explicitly define their required checks in their local `renovate.json` to override
the bot's global behavior.

## Verification

Once merged, Renovate should begin automerging pending security updates on the next
run. Monitor the logs for Automerging actions.

Closes #24
