### PR TITLE
fix(infra): redirect tooling data and cache to writable paths

### DIFF
--- a/config.js
+++ b/config.js
@@ -48,10 +48,11 @@ module.exports = {
   ],
   allowedCommands: ["^(?:\\./)?tools/[\\w-]+\\.sh.*$"],
   allowShellExecutorForPostUpgradeCommands: true,
-  // Go override to ensure go tools have the right permissions
+  // Tool environment overrides to ensure tools have the right permissions
   customEnvVariables: {
-    GOCACHE: '/tmp/renovate/cache/go-build',
-    GOPATH: '/tmp/renovate/cache/go',
-    HOME: '/tmp/renovate', // Keeps tools out of /home/ubuntu
+    HOME: '/tmp/renovate',
+    XDG_DATA_HOME: '$/tmp/renovate/.local/share',
+    XDG_CACHE_HOME: '$/tmp/renovate/cache',  // Enables automatic discovery for UV, Go
+    GOPATH: '$/tmp/renovate/cache/go'        // Required: Go doesn't use XDG_DATA_HOME
   }
 };


### PR DESCRIPTION
## Description

This PR fixes “Artifact update problems” encountered in repositories using UV dependencies.

After Renovate updates a UV dependency, it runs commands like `uv lock`. These commands attempt to write to
`/home/ubuntu/.local/share/uv/` and `/home/ubuntu/.cache/uv`, which results in  permission denied errors due to the bot’s restricted configuration.

We previously solved a similar issue with Go tools (#20, #21) by introducing custom environment variables. Rather than adding tool-specific variables for each new case, this PR adopts XDG environment variables. These are supported by UV, Go, and many other tools, allowing us to standardize configuration while reserving tool-specific variables only for tools that do not follow the XDG specification.

## Changes implemented

- Add `XDG_DATA_HOME` and `XDG_CACHE_HOME` as custom environment variables.
- Remove redundant `GOCACHE` env variable (respects XDG spec).

## Impact

These changes allow `go get`, `uv lock` and other toolchain operations to complete successfully without requiring root access to the container's internal filesystem.

Closes  #34 #35 
