### PR TITLE
chore(ci): add renovate config validation to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,9 @@ repos:
       types_or: [ python, pyi, pyproject ]
     - id: ruff-format
       types_or: [ python, pyi, pyproject ]
+
+-   repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 43.76.5
+    hooks:
+      - id: renovate-config-validator
+        args: [--strict]


### PR DESCRIPTION
## Description

This PR adds Renovate config validation as a pre-commit hook to the local development
workflow.

## What changed

- Added a `renovate-config-validator` hook to `.pre-commit-config.yaml`

## Impact

Enable developers to validate config changes locally before committing changes.

## Verification

- Modify `config.js` or `renovate.json` to include an invalid config.
- Attempt to commit the modified file
- Observe pre-commit block the commit, raising a Renovate config validation error

