### PR TITLE
chore(ci): configure pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,15 @@ repos:
     hooks:
       - id: renovate-config-validator
         args: [--strict]
+
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: 'pre-commit/autoupdate'
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: quarterly
+    skip: []
+    submodules: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Renovate Pi Bot
 
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/Marlon-Gomes/renovate-pi-bot/main.svg)](https://results.pre-commit.ci/latest/github/Marlon-Gomes/renovate-pi-bot/main)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A self-hosted, containerized Renovate instance. This bot automates dependency


### PR DESCRIPTION
## Description

This PR configures [pre-commit.ci](https://pre-commit.ci) for this repo.

## What changed

- Added a `ci` section to `.pre-commit-config.yaml` configuring the service
- Replaced the static `pre-commit` enabled badge with a dynamic
`pre-commit.ci` badge that reports the status of the latest run.

## Impact

Integrates pre-commit with our CI pipeline to avoid relying solely on
contributors' judgment to install the hooks on their development environments
and reviewers' judgment to check PRs pass pre-commit checks

